### PR TITLE
JWT 및 OAuth 2.0을 통한 로그인 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -7,7 +7,6 @@ plugins {
 
 group = 'our.portfolio'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
 
 configurations {
     compileOnly {
@@ -33,12 +32,17 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
+
+    compileOnly 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-    testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.16.0'
+    testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.16.2'
 }
 
 test {

--- a/backend/src/main/java/our/portfolio/devspace/common/utils/CookieUtils.java
+++ b/backend/src/main/java/our/portfolio/devspace/common/utils/CookieUtils.java
@@ -1,0 +1,62 @@
+package our.portfolio.devspace.common.utils;
+
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Optional;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.util.SerializationUtils;
+
+public final class CookieUtils {
+
+    private CookieUtils() {
+        throw new IllegalStateException("이 클래스를 인스턴스화하지 마세요.");
+    }
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null && cookies.length > 0) {
+            return Arrays.stream(cookies)
+                .filter(cookie -> cookie.getName().equals(name))
+                .findFirst();
+        }
+        return Optional.empty();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Optional<Cookie> cookie = getCookie(request, name);
+
+        if (cookie.isPresent()) {
+            Cookie c = cookie.get();
+            c.setValue("");
+            c.setPath("/");
+            c.setMaxAge(0);
+
+            response.addCookie(c);
+        }
+    }
+
+    public static String serialize(Object obj) {
+        return Base64.getUrlEncoder()
+            .encodeToString(SerializationUtils.serialize(obj));
+    }
+
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return cls.cast(
+            SerializationUtils.deserialize(
+                Base64.getUrlDecoder().decode(cookie.getValue())
+            )
+        );
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/configuration/WebSecurityConfiguration.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/WebSecurityConfiguration.java
@@ -1,21 +1,81 @@
 package our.portfolio.devspace.configuration;
 
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import our.portfolio.devspace.configuration.security.oauth.handler.OAuth2AuthenticationFailureHandler;
+import our.portfolio.devspace.configuration.security.oauth.handler.OAuth2AuthenticationSuccessHandler;
+import our.portfolio.devspace.configuration.security.oauth.jwt.JwtAccessDeniedHandler;
+import our.portfolio.devspace.configuration.security.oauth.jwt.JwtAuthenticationEntryPoint;
+import our.portfolio.devspace.configuration.security.oauth.jwt.JwtAuthenticationFilter;
+import our.portfolio.devspace.configuration.security.oauth.jwt.JwtTokenProvider;
+import our.portfolio.devspace.configuration.security.oauth.repository.HttpCookieOAuth2AuthorizationRequestRepository;
+import our.portfolio.devspace.configuration.security.oauth.service.CustomOAuth2UserService;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebSecurityConfiguration {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAuthenticationEntryPoint authenticationErrorHandler;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final CustomOAuth2UserService oauthUserService;
+    private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+    private final OAuth2AuthenticationFailureHandler oauth2AuthenticationFailureHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.csrf().disable().headers().frameOptions().disable() // H2 콘솔 사용 설정
-            .and()
+        http
+            .csrf().disable()
+            .headers().frameOptions().disable().and() // H2 콘솔 사용 설정
             .authorizeHttpRequests(authorize -> authorize
                 .anyRequest().permitAll()
-            );
+            )
+            .exceptionHandling()
+                .authenticationEntryPoint(authenticationErrorHandler)
+                .accessDeniedHandler(jwtAccessDeniedHandler)
+            .and()
+            .cors().configurationSource(corsConfigurationSource()).and()
+            .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+            .oauth2Login()
+                .authorizationEndpoint()
+                    .baseUri("/oauth2/authorization")
+                    .authorizationRequestRepository(httpCookieOAuth2AuthorizationRequestRepository)
+                    .and()
+                .redirectionEndpoint()
+                    .baseUri("/*/oauth2/code/*")
+                    .and()
+                .userInfoEndpoint()
+                    .userService(oauthUserService)
+                    .and()
+                .successHandler(oAuth2AuthenticationSuccessHandler)
+                .failureHandler(oauth2AuthenticationFailureHandler)
+                .and()
+            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                UsernamePasswordAuthenticationFilter.class);
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.addAllowedOriginPattern("*");
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/domain/OAuth2UserPrincipal.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/domain/OAuth2UserPrincipal.java
@@ -1,0 +1,87 @@
+package our.portfolio.devspace.configuration.security.oauth.domain;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import our.portfolio.devspace.domain.user.Role;
+import our.portfolio.devspace.domain.user.User;
+
+@Getter
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class OAuth2UserPrincipal implements OAuth2User, UserDetails {
+    private final String username;
+    private final Role role;
+    private final Collection<GrantedAuthority> authorities;
+    private Map<String, Object> attributes;
+
+    public static OAuth2UserPrincipal from(User user) {
+        return new OAuth2UserPrincipal(
+            user.getEmail(),
+            user.getRole(),
+            Collections.singletonList(new SimpleGrantedAuthority(user.getRole().getCode()))
+        );
+    }
+
+    public static OAuth2UserPrincipal from(User user, Map<String, Object> attributes) {
+        OAuth2UserPrincipal userPrincipal = from(user);
+        userPrincipal.setAttributes(attributes);
+        return userPrincipal;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getName() {
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public void setAttributes(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/handler/OAuth2AuthenticationFailureHandler.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/handler/OAuth2AuthenticationFailureHandler.java
@@ -7,6 +7,7 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
@@ -20,12 +21,15 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 
     private final HttpCookieOAuth2AuthorizationRequestRepository authorizationRequestRepository;
 
+    @Value("${security.oauth.default-redirect-uri}")
+    private String defaultRedirectUri;
+
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
         AuthenticationException exception) throws IOException {
         String targetUrl = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
             .map(Cookie::getValue)
-            .orElse(("/"));
+            .orElse(defaultRedirectUri);
 
         targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
             .queryParam("error", exception.getLocalizedMessage())

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/handler/OAuth2AuthenticationFailureHandler.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/handler/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,38 @@
+package our.portfolio.devspace.configuration.security.oauth.handler;
+
+import static our.portfolio.devspace.configuration.security.oauth.repository.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
+
+import java.io.IOException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+import our.portfolio.devspace.common.utils.CookieUtils;
+import our.portfolio.devspace.configuration.security.oauth.repository.HttpCookieOAuth2AuthorizationRequestRepository;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    private final HttpCookieOAuth2AuthorizationRequestRepository authorizationRequestRepository;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException exception) throws IOException {
+        String targetUrl = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+            .map(Cookie::getValue)
+            .orElse(("/"));
+
+        targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
+            .queryParam("error", exception.getLocalizedMessage())
+            .build().toUriString();
+
+        authorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -33,8 +33,11 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     private final UserRefreshTokenRepository userRefreshTokenRepository;
     private final HttpCookieOAuth2AuthorizationRequestRepository authorizationRequestRepository;
 
+    @Value("${security.oauth.default-redirect-uri}")
+    private String defaultRedirectUri;
+
     @Value("${security.oauth.authorized-redirect-uri}")
-    String[] authorizedRedirectUris;
+    private String[] authorizedRedirectUris;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -63,7 +66,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             throw new IllegalArgumentException("Sorry! We've got an Unauthorized Redirect URI and can't proceed with the authentication");
         }
 
-        return redirectUri.orElse(getDefaultTargetUrl());
+        return redirectUri.orElse(defaultRedirectUri);
     }
 
     private String saveRefreshToken(Authentication authentication) {

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,99 @@
+package our.portfolio.devspace.configuration.security.oauth.handler;
+
+import static our.portfolio.devspace.configuration.security.oauth.repository.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
+import static our.portfolio.devspace.configuration.security.oauth.repository.HttpCookieOAuth2AuthorizationRequestRepository.REFRESH_TOKEN_PARAM_COOKIE_NAME;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Optional;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+import our.portfolio.devspace.common.utils.CookieUtils;
+import our.portfolio.devspace.configuration.security.oauth.jwt.JwtTokenProvider;
+import our.portfolio.devspace.configuration.security.oauth.repository.HttpCookieOAuth2AuthorizationRequestRepository;
+import our.portfolio.devspace.domain.user.UserRefreshToken;
+import our.portfolio.devspace.repository.UserRefreshTokenRepository;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtTokenProvider tokenProvider;
+    private final UserRefreshTokenRepository userRefreshTokenRepository;
+    private final HttpCookieOAuth2AuthorizationRequestRepository authorizationRequestRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) throws IOException {
+        String targetUrl = determineTargetUrl(request, response, authentication);
+
+        if (response.isCommitted()) {
+            log.error("Response has already been committed. Unable to redirect to " + targetUrl);
+            return;
+        }
+
+        clearAuthenticationAttributes(request, response);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+
+    protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
+        super.clearAuthenticationAttributes(request);
+        authorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+    }
+
+    private String getTargetUrl(HttpServletRequest request) {
+        Optional<String> redirectUri = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+            .map(Cookie::getValue);
+
+        if(redirectUri.isPresent()) {
+            throw new IllegalArgumentException("Sorry! We've got an Unauthorized Redirect URI and can't proceed with the authentication");
+        }
+
+        return redirectUri.orElse(getDefaultTargetUrl());
+    }
+
+    private String saveRefreshToken(Authentication authentication) {
+        String refreshToken = tokenProvider.createRefreshToken(authentication);
+
+        OAuth2User user = (OAuth2User)authentication.getPrincipal();
+
+        Optional<UserRefreshToken> userRefreshToken = userRefreshTokenRepository.findByEmail(user.getName());
+        if (userRefreshToken.isPresent()) {
+            userRefreshToken.get().reissueToken(refreshToken);
+        } else {
+            userRefreshTokenRepository.save(new UserRefreshToken(user.getName(), refreshToken));
+        }
+        return refreshToken;
+    }
+
+    @Override
+    protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        String targetUrl = getTargetUrl(request);
+        String accessToken = tokenProvider.createAccessToken(authentication);
+        String refreshToken = saveRefreshToken(authentication);
+
+        addRefreshTokenCookie(request, response, refreshToken);
+
+        log.info("accessToken: {}", accessToken);
+        return UriComponentsBuilder.fromUriString(targetUrl)
+            .queryParam("token", accessToken)
+            .build().toUriString();
+    }
+
+    private void addRefreshTokenCookie(HttpServletRequest request, HttpServletResponse response, String refreshToken) {
+        int cookieMaxAge = (int) tokenProvider.getRefreshExpirationTime() / 60;
+
+        CookieUtils.deleteCookie(request, response, REFRESH_TOKEN_PARAM_COOKIE_NAME);
+        CookieUtils.addCookie(response, REFRESH_TOKEN_PARAM_COOKIE_NAME, refreshToken, cookieMaxAge);
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/jwt/JwtAccessDeniedHandler.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,18 @@
+package our.portfolio.devspace.configuration.security.oauth.jwt;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(
+        HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN, accessDeniedException.getMessage());
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/jwt/JwtAuthenticationEntryPoint.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,21 @@
+package our.portfolio.devspace.configuration.security.oauth.jwt;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        AuthenticationException authException
+    ) throws IOException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authException.getMessage());
+    }
+}
+

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package our.portfolio.devspace.configuration.security.oauth.jwt;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider tokenProvider;
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+
+    @Override
+    protected void doFilterInternal(
+       @NonNull HttpServletRequest request,
+       @NonNull HttpServletResponse response,
+       @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        final String resolvedToken = resolveToken(request);
+
+        if (StringUtils.hasText(resolvedToken) && tokenProvider.validateToken(resolvedToken)) {
+            Authentication authentication = tokenProvider.getAuthentication(resolvedToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.info("Authenticated user: {}, uri: {}", authentication.getName(), request.getRequestURI());
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (isValidHeader(bearerToken)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    private boolean isValidHeader(String header) {
+        return header != null && header.startsWith("Bearer ");
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/jwt/JwtTokenProvider.java
@@ -1,0 +1,107 @@
+package our.portfolio.devspace.configuration.security.oauth.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtTokenProvider implements InitializingBean {
+
+    private static final String AUTHORITIES_KEY = "auth";
+    private Key key;
+
+    private final String base64Secret;
+    private final long expirationTime;
+    private final long refreshExpirationTime;
+
+    public JwtTokenProvider(
+        @Value("${security.jwt.base64-secret}") String base64Secret,
+        @Value("${security.jwt.expiration-time}") long expirationTime,
+        @Value("${security.jwt.refresh-expiration-time}") long refreshExpirationTime
+    ) {
+        this.base64Secret = base64Secret;
+        this.expirationTime = expirationTime;
+        this.refreshExpirationTime = refreshExpirationTime;
+    }
+
+    public String createAccessToken(Authentication authentication) {
+        String authorities = authentication.getAuthorities().stream()
+            .map(GrantedAuthority::getAuthority)
+            .collect(Collectors.joining(","));
+        return Jwts.builder()
+            .setSubject(authentication.getName())
+            .claim(AUTHORITIES_KEY, authorities)
+            .setIssuedAt(new Date(System.currentTimeMillis()))
+            .setExpiration(new Date(System.currentTimeMillis() + expirationTime))
+            .signWith(key, SignatureAlgorithm.HS512)
+            .compact();
+    }
+
+    public String createRefreshToken(Authentication authentication) {
+        return Jwts.builder()
+            .setSubject(authentication.getName())
+            .setExpiration(new Date(System.currentTimeMillis() + refreshExpirationTime))
+            .signWith(key, SignatureAlgorithm.HS512)
+            .compact();
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        byte[] secretKeyBytes = Decoders.BASE64.decode(base64Secret);
+        this.key = Keys.hmacShaKeyFor(secretKeyBytes);
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = getAllClaimsFromToken(token).getBody();
+        Collection<? extends GrantedAuthority> authorities =
+            Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+        User principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            getAllClaimsFromToken(token);
+            return true;
+        } catch (JwtException ex) {
+            log.trace("Invalid JWT token trace: {}", ex.toString());
+            return false;
+        }
+    }
+
+    private Jws<Claims> getAllClaimsFromToken(String token) {
+        return Jwts.parserBuilder()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(token);
+    }
+
+    public long getExpirationTime() {
+        return expirationTime;
+    }
+
+    public long getRefreshExpirationTime() {
+        return refreshExpirationTime;
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/repository/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/repository/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,61 @@
+package our.portfolio.devspace.configuration.security.oauth.repository;
+
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Repository;
+import our.portfolio.devspace.common.utils.CookieUtils;
+
+@Repository
+public class HttpCookieOAuth2AuthorizationRequestRepository
+    implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+    public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+    public static final String REFRESH_TOKEN_PARAM_COOKIE_NAME = "refresh_token";
+
+    private static final int COOKIE_EXPIRES_SECONDS = 180;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return CookieUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+            .map(cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+            .orElse(null);
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request,
+        HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+            CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+            CookieUtils.deleteCookie(request, response, REFRESH_TOKEN_PARAM_COOKIE_NAME);
+            return;
+        }
+
+        CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+            CookieUtils.serialize(authorizationRequest), COOKIE_EXPIRES_SECONDS);
+        String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+            CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, COOKIE_EXPIRES_SECONDS);
+        }
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
+        return this.loadAuthorizationRequest(request);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+        HttpServletResponse response) {
+        return this.loadAuthorizationRequest(request);
+    }
+
+    public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+        CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+        CookieUtils.deleteCookie(request, response, REFRESH_TOKEN_PARAM_COOKIE_NAME);
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/repository/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/repository/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -28,9 +28,7 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
     public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request,
         HttpServletResponse response) {
         if (authorizationRequest == null) {
-            CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
-            CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
-            CookieUtils.deleteCookie(request, response, REFRESH_TOKEN_PARAM_COOKIE_NAME);
+            removeAuthorizationRequestCookies(request, response);
             return;
         }
 

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/service/CustomOAuth2UserService.java
@@ -1,0 +1,44 @@
+package our.portfolio.devspace.configuration.security.oauth.service;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import our.portfolio.devspace.configuration.security.oauth.domain.OAuth2UserPrincipal;
+import our.portfolio.devspace.configuration.security.oauth.userinfo.OAuth2UserInfo;
+import our.portfolio.devspace.configuration.security.oauth.userinfo.OAuth2UserInfoFactory;
+import our.portfolio.devspace.domain.user.Role;
+import our.portfolio.devspace.domain.user.User;
+import our.portfolio.devspace.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2UserInfo userInfo = OAuth2UserInfoFactory.of(registrationId, oAuth2User.getAttributes());
+
+        Optional<User> foundUser = userRepository.findByEmail(userInfo.getEmail());
+        if (foundUser.isEmpty()) {
+            return OAuth2UserPrincipal.from(createUser(userInfo));
+        }
+        return OAuth2UserPrincipal.from(foundUser.get(), oAuth2User.getAttributes());
+    }
+
+    private User createUser(OAuth2UserInfo userInfo) {
+        User newUser = User.builder()
+            .email(userInfo.getEmail())
+            .name(userInfo.getName())
+            .role(Role.USER)
+            .build();
+        return userRepository.save(newUser);
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/userinfo/GithubOAuth2UserInfo.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/userinfo/GithubOAuth2UserInfo.java
@@ -1,0 +1,25 @@
+package our.portfolio.devspace.configuration.security.oauth.userinfo;
+
+import java.util.Map;
+
+public class GithubOAuth2UserInfo extends OAuth2UserInfo {
+
+    protected GithubOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public OAuth2Provider getProvider() {
+        return OAuth2Provider.GITHUB;
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/userinfo/GoogleOAuth2UserInfo.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/userinfo/GoogleOAuth2UserInfo.java
@@ -1,0 +1,26 @@
+package our.portfolio.devspace.configuration.security.oauth.userinfo;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
+
+    protected GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public OAuth2Provider getProvider() {
+        return OAuth2Provider.GOOGLE;
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+}
+

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/userinfo/OAuth2Provider.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/userinfo/OAuth2Provider.java
@@ -1,0 +1,20 @@
+package our.portfolio.devspace.configuration.security.oauth.userinfo;
+
+public enum OAuth2Provider {
+    GOOGLE("google"),
+    GITHUB("github");
+
+    private final String provider;
+
+    OAuth2Provider(String provider) {
+        this.provider = provider;
+    }
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public boolean equalsWith(String provider) {
+        return this.provider.equalsIgnoreCase(provider);
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/userinfo/OAuth2UserInfo.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/userinfo/OAuth2UserInfo.java
@@ -1,0 +1,29 @@
+package our.portfolio.devspace.configuration.security.oauth.userinfo;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+    protected final Map<String, Object> attributes;
+
+    protected OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    /**
+     * 인증 정보에서 프로바이더를 반환합니다.
+     * <p>
+     * 프로바이더는 Google, Kakao, Naver 등과 같은 OAuth 서비스를 제공하는 제공자를 말합니다.
+     *
+     * @return 프로바이더 (null이 아님)
+     */
+    public abstract OAuth2Provider getProvider();
+
+    public abstract String getEmail();
+
+    public abstract String getName();
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+}
+

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/userinfo/OAuth2UserInfoFactory.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/userinfo/OAuth2UserInfoFactory.java
@@ -1,0 +1,29 @@
+package our.portfolio.devspace.configuration.security.oauth.userinfo;
+
+import java.util.Map;
+
+public final class OAuth2UserInfoFactory {
+
+    private OAuth2UserInfoFactory() {
+        throw new IllegalStateException("이 클래스를 인스턴스화하지 마세요.");
+    }
+
+    /**
+     * 프로바이더에게 받은 인증 정보를 반환합니다.
+     * <p>
+     * {@code attributes}는 프로바이더가 보낸 인증된 사용자의 세부정보를 담고 있습니다.
+     *
+     * @param registrationId 프로바이더 ID
+     * @param attributes 최종 사용자(리소스 소유자)의 속성
+     * @return 인증 정보
+     */
+    public static OAuth2UserInfo of(String registrationId, Map<String, Object> attributes) {
+        if (OAuth2Provider.GOOGLE.equalsWith(registrationId)) {
+            return new GoogleOAuth2UserInfo(attributes);
+        } else if (OAuth2Provider.GITHUB.equalsWith(registrationId)) {
+            return new GithubOAuth2UserInfo(attributes);
+        } else {
+            throw new IllegalArgumentException(String.format("%s는 알 수 없는 프로바이더 타입입니다.", registrationId));
+        }
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/domain/user/Role.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/user/Role.java
@@ -1,0 +1,22 @@
+package our.portfolio.devspace.domain.user;
+
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN"),
+    GUEST("GUEST");
+
+    private final String code;
+
+    public static Role from(String code) {
+        return Arrays.stream(Role.values())
+            .filter(r -> r.getCode().equals(code))
+            .findAny()
+            .orElse(GUEST);
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/domain/user/User.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/user/User.java
@@ -2,6 +2,8 @@ package our.portfolio.devspace.domain.user;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -34,6 +36,9 @@ public class User extends BaseTimeEntity {
 
     @Column(columnDefinition = "TEXT")
     private String introduction;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "job_id", nullable = false)

--- a/backend/src/main/java/our/portfolio/devspace/domain/user/User.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/user/User.java
@@ -41,16 +41,15 @@ public class User extends BaseTimeEntity {
     private Role role;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "job_id", nullable = false)
+    @JoinColumn(name = "job_id")
     private Job job;
 
     @Builder
-    public User(String email, String name, String introduction, Job job) {
+    public User(String email, String name, String introduction, Job job, Role role) {
         this.email = email;
         this.name = name;
         this.introduction = introduction;
         this.job = job;
-
-        job.getUsers().add(this);
+        this.role = role;
     }
 }

--- a/backend/src/main/java/our/portfolio/devspace/domain/user/UserRefreshToken.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/user/UserRefreshToken.java
@@ -32,4 +32,8 @@ public class UserRefreshToken {
         this.email = email;
         this.token = token;
     }
+
+    public void reissueToken(String newRefreshToken) {
+        this.token = newRefreshToken;
+    }
 }

--- a/backend/src/main/java/our/portfolio/devspace/repository/UserRefreshTokenRepository.java
+++ b/backend/src/main/java/our/portfolio/devspace/repository/UserRefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package our.portfolio.devspace.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import our.portfolio.devspace.domain.user.UserRefreshToken;
+
+public interface UserRefreshTokenRepository extends JpaRepository<UserRefreshToken, Long> {
+}

--- a/backend/src/main/java/our/portfolio/devspace/repository/UserRefreshTokenRepository.java
+++ b/backend/src/main/java/our/portfolio/devspace/repository/UserRefreshTokenRepository.java
@@ -1,7 +1,9 @@
 package our.portfolio.devspace.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import our.portfolio.devspace.domain.user.UserRefreshToken;
 
 public interface UserRefreshTokenRepository extends JpaRepository<UserRefreshToken, Long> {
+    Optional<UserRefreshToken> findByEmail(String email);
 }

--- a/backend/src/main/java/our/portfolio/devspace/repository/UserRepository.java
+++ b/backend/src/main/java/our/portfolio/devspace/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package our.portfolio.devspace.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import our.portfolio.devspace.domain.user.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}


### PR DESCRIPTION
# 설명
JWT 및 OAuth 2.0을 통해서 깃허브와 구글 계정을 통한 로그인을 지원합니다. 구체적인 동작은 [노션](https://www.notion.so/JWT-OAuth-2-0-6aae54ddd17a4958a7c93e0d43b774d8)에서 확인할 수 있습니다.

## 변경 유형
- [x] 호환성을 깨뜨리는 변경 (기존 기능이 기대하는 대로 작동하지 않을 수 있는 수정 혹은 기능)
- [x] 이 변경 내역을 적용하려면 문서를 업데이트해야 함