### PR TITLE
회원가입, 로그인 과정에서 email 제거

### DIFF
--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/domain/OAuth2UserPrincipal.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/domain/OAuth2UserPrincipal.java
@@ -10,13 +10,16 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import our.portfolio.devspace.domain.user.Role;
-import our.portfolio.devspace.domain.user.User;
+import our.portfolio.devspace.domain.user.entity.Role;
+import our.portfolio.devspace.domain.user.entity.User;
 
 @Getter
 @AllArgsConstructor
 @RequiredArgsConstructor
 public class OAuth2UserPrincipal implements OAuth2User, UserDetails {
+
+    @Getter
+    private final Long id;
     private final String username;
     private final Role role;
     private final Collection<GrantedAuthority> authorities;
@@ -24,7 +27,8 @@ public class OAuth2UserPrincipal implements OAuth2User, UserDetails {
 
     public static OAuth2UserPrincipal from(User user) {
         return new OAuth2UserPrincipal(
-            user.getEmail(),
+            user.getId(),
+            user.getName(),
             user.getRole(),
             Collections.singletonList(new SimpleGrantedAuthority(user.getRole().getCode()))
         );
@@ -39,6 +43,10 @@ public class OAuth2UserPrincipal implements OAuth2User, UserDetails {
     @Override
     public Map<String, Object> getAttributes() {
         return attributes;
+    }
+
+    public void setAttributes(Map<String, Object> attributes) {
+        this.attributes = attributes;
     }
 
     @Override
@@ -79,9 +87,5 @@ public class OAuth2UserPrincipal implements OAuth2User, UserDetails {
     @Override
     public boolean isEnabled() {
         return true;
-    }
-
-    public void setAttributes(Map<String, Object> attributes) {
-        this.attributes = attributes;
     }
 }

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/jwt/JwtTokenProvider.java
@@ -21,6 +21,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.stereotype.Component;
+import our.portfolio.devspace.configuration.security.oauth.domain.OAuth2UserPrincipal;
 
 @Slf4j
 @Component
@@ -43,12 +44,12 @@ public class JwtTokenProvider implements InitializingBean {
         this.refreshExpirationTime = refreshExpirationTime;
     }
 
-    public String createAccessToken(Authentication authentication) {
-        String authorities = authentication.getAuthorities().stream()
+    public String createAccessToken(OAuth2UserPrincipal principal) {
+        String authorities = principal.getAuthorities().stream()
             .map(GrantedAuthority::getAuthority)
             .collect(Collectors.joining(","));
         return Jwts.builder()
-            .setSubject(authentication.getName())
+            .setSubject(principal.getId().toString())
             .claim(AUTHORITIES_KEY, authorities)
             .setIssuedAt(new Date(System.currentTimeMillis()))
             .setExpiration(new Date(System.currentTimeMillis() + expirationTime))
@@ -56,9 +57,9 @@ public class JwtTokenProvider implements InitializingBean {
             .compact();
     }
 
-    public String createRefreshToken(Authentication authentication) {
+    public String createRefreshToken(OAuth2UserPrincipal principal) {
         return Jwts.builder()
-            .setSubject(authentication.getName())
+            .setSubject(principal.getId().toString())
             .setExpiration(new Date(System.currentTimeMillis() + refreshExpirationTime))
             .signWith(key, SignatureAlgorithm.HS512)
             .compact();

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/service/CustomOAuth2UserService.java
@@ -26,7 +26,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         OAuth2UserInfo userInfo = OAuth2UserInfoFactory.of(registrationId, oAuth2User.getAttributes());
 
-        Optional<User> foundUser = userRepository.findByEmail(userInfo.getEmail());
+        Optional<User> foundUser = userRepository.findBySubjectAndProvider(userInfo.getSubject(), userInfo.getProvider());
         if (foundUser.isEmpty()) {
             return OAuth2UserPrincipal.from(createUser(userInfo));
         }
@@ -35,7 +35,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private User createUser(OAuth2UserInfo userInfo) {
         User newUser = User.builder()
-            .email(userInfo.getEmail())
+            .subject(userInfo.getSubject())
+            .provider(userInfo.getProvider())
             .name(userInfo.getName())
             .role(Role.USER)
             .build();

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/service/CustomOAuth2UserService.java
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Service;
 import our.portfolio.devspace.configuration.security.oauth.domain.OAuth2UserPrincipal;
 import our.portfolio.devspace.configuration.security.oauth.userinfo.OAuth2UserInfo;
 import our.portfolio.devspace.configuration.security.oauth.userinfo.OAuth2UserInfoFactory;
-import our.portfolio.devspace.domain.user.Role;
-import our.portfolio.devspace.domain.user.User;
+import our.portfolio.devspace.domain.user.entity.Role;
+import our.portfolio.devspace.domain.user.entity.User;
 import our.portfolio.devspace.repository.UserRepository;
 
 @Service

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/userinfo/GithubOAuth2UserInfo.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/userinfo/GithubOAuth2UserInfo.java
@@ -14,8 +14,8 @@ public class GithubOAuth2UserInfo extends OAuth2UserInfo {
     }
 
     @Override
-    public String getEmail() {
-        return (String) attributes.get("email");
+    public String getSubject() {
+        return attributes.get("id").toString();
     }
 
     @Override

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/userinfo/GoogleOAuth2UserInfo.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/userinfo/GoogleOAuth2UserInfo.java
@@ -14,8 +14,8 @@ public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
     }
 
     @Override
-    public String getEmail() {
-        return (String) attributes.get("email");
+    public String getSubject() {
+        return (String) attributes.get("sub");
     }
 
     @Override

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/userinfo/OAuth2UserInfo.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/userinfo/OAuth2UserInfo.java
@@ -18,7 +18,7 @@ public abstract class OAuth2UserInfo {
      */
     public abstract OAuth2Provider getProvider();
 
-    public abstract String getEmail();
+    public abstract String getSubject();
 
     public abstract String getName();
 

--- a/backend/src/main/java/our/portfolio/devspace/domain/job/Job.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/job/Job.java
@@ -13,7 +13,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import our.portfolio.devspace.domain.user.User;
+import our.portfolio.devspace.domain.profile.entity.Profile;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,7 +22,7 @@ import our.portfolio.devspace.domain.user.User;
 public class Job {
 
     @OneToMany(mappedBy = "job")
-    private final List<User> users = new ArrayList<>();
+    private final List<Profile> profiles = new ArrayList<>();
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/our/portfolio/devspace/domain/job/repository/JobRepository.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/job/repository/JobRepository.java
@@ -1,0 +1,8 @@
+package our.portfolio.devspace.domain.job.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import our.portfolio.devspace.domain.job.Job;
+
+public interface JobRepository extends JpaRepository<Job, Integer> {
+
+}

--- a/backend/src/main/java/our/portfolio/devspace/domain/profile/entity/Profile.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/profile/entity/Profile.java
@@ -1,0 +1,52 @@
+package our.portfolio.devspace.domain.profile.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MapsId;
+import javax.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import our.portfolio.devspace.domain.BaseTimeEntity;
+import our.portfolio.devspace.domain.job.Job;
+import our.portfolio.devspace.domain.user.entity.User;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Profile extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "user_id")
+    private Long id;
+
+    @MapsId
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(columnDefinition = "TEXT")
+    private String introduction;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "job_id", nullable = false)
+    private Job job;
+
+    private String profile_image;
+    private String profile_bg_image;
+
+    @Builder
+    public Profile(User user, String introduction, Job job, String profile_image,
+        String profile_bg_image) {
+        this.user = user;
+        this.introduction = introduction;
+        this.job = job;
+        this.profile_image = profile_image;
+        this.profile_bg_image = profile_bg_image;
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/domain/profile/repository/ProfileRepository.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/profile/repository/ProfileRepository.java
@@ -1,0 +1,8 @@
+package our.portfolio.devspace.domain.profile.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import our.portfolio.devspace.domain.profile.entity.Profile;
+
+public interface ProfileRepository extends JpaRepository<Profile, Long> {
+
+}

--- a/backend/src/main/java/our/portfolio/devspace/domain/user/entity/Role.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/user/entity/Role.java
@@ -1,4 +1,4 @@
-package our.portfolio.devspace.domain.user;
+package our.portfolio.devspace.domain.user.entity;
 
 import java.util.Arrays;
 import lombok.Getter;

--- a/backend/src/main/java/our/portfolio/devspace/domain/user/entity/User.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/user/entity/User.java
@@ -32,8 +32,9 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private String subject;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
-    private OAuth2Provider provider = OAuth2Provider.GOOGLE;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private OAuth2Provider provider;
 
     @Column(nullable = false, length = 12)
     private String name;

--- a/backend/src/main/java/our/portfolio/devspace/domain/user/entity/User.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/user/entity/User.java
@@ -1,22 +1,23 @@
-package our.portfolio.devspace.domain.user;
+package our.portfolio.devspace.domain.user.entity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import our.portfolio.devspace.configuration.security.oauth.userinfo.OAuth2Provider;
 import our.portfolio.devspace.domain.BaseTimeEntity;
-import our.portfolio.devspace.domain.job.Job;
+import our.portfolio.devspace.domain.profile.entity.Profile;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -28,28 +29,32 @@ public class User extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
-    private String email;
+    @Column(nullable = false)
+    private String subject;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private OAuth2Provider provider = OAuth2Provider.GOOGLE;
 
     @Column(nullable = false, length = 12)
     private String name;
 
-    @Column(columnDefinition = "TEXT")
-    private String introduction;
-
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "job_id")
-    private Job job;
+    @Setter(AccessLevel.PACKAGE)
+    @OneToOne(mappedBy = "user")
+    @PrimaryKeyJoinColumn
+    private Profile profile;
 
     @Builder
-    public User(String email, String name, String introduction, Job job, Role role) {
-        this.email = email;
+    public User(String subject, OAuth2Provider provider, String name, Role role) {
+        this.subject = subject;
+        this.provider = provider;
         this.name = name;
-        this.introduction = introduction;
-        this.job = job;
         this.role = role;
+    }
+
+    public void modifyName(String name) {
+        this.name = name;
     }
 }

--- a/backend/src/main/java/our/portfolio/devspace/domain/user/entity/UserRefreshToken.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/user/entity/UserRefreshToken.java
@@ -1,4 +1,4 @@
-package our.portfolio.devspace.domain.user;
+package our.portfolio.devspace.domain.user.entity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -22,14 +22,14 @@ public class UserRefreshToken {
     private Long id;
 
     @Column(nullable = false, unique = true)
-    private String email;
+    private Long userId;
 
     @Column(nullable = false)
     private String token;
 
     @Builder
-    public UserRefreshToken(String email, String token) {
-        this.email = email;
+    public UserRefreshToken(Long userId, String token) {
+        this.userId = userId;
         this.token = token;
     }
 

--- a/backend/src/main/java/our/portfolio/devspace/repository/UserRefreshTokenRepository.java
+++ b/backend/src/main/java/our/portfolio/devspace/repository/UserRefreshTokenRepository.java
@@ -2,7 +2,7 @@ package our.portfolio.devspace.repository;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import our.portfolio.devspace.domain.user.UserRefreshToken;
+import our.portfolio.devspace.domain.user.entity.UserRefreshToken;
 
 public interface UserRefreshTokenRepository extends JpaRepository<UserRefreshToken, Long> {
     Optional<UserRefreshToken> findByEmail(String email);

--- a/backend/src/main/java/our/portfolio/devspace/repository/UserRefreshTokenRepository.java
+++ b/backend/src/main/java/our/portfolio/devspace/repository/UserRefreshTokenRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import our.portfolio.devspace.domain.user.entity.UserRefreshToken;
 
 public interface UserRefreshTokenRepository extends JpaRepository<UserRefreshToken, Long> {
-    Optional<UserRefreshToken> findByEmail(String email);
+    Optional<UserRefreshToken> findByUserId(Long userId);
 }

--- a/backend/src/main/java/our/portfolio/devspace/repository/UserRepository.java
+++ b/backend/src/main/java/our/portfolio/devspace/repository/UserRepository.java
@@ -2,8 +2,9 @@ package our.portfolio.devspace.repository;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import our.portfolio.devspace.domain.user.User;
+import our.portfolio.devspace.configuration.security.oauth.userinfo.OAuth2Provider;
+import our.portfolio.devspace.domain.user.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByEmail(String email);
+    Optional<User> findBySubjectAndProvider(String subject, OAuth2Provider provider);
 }


### PR DESCRIPTION
- email 대신 oauth2 provider와 subject를 사용하도록 변경
- jwt 토큰의 sub를 email 대신 user id로 변경
- 마지막 리다이렉트 url에 token과 함께 user id, job을 포함하도록 변경