### PR TITLE
전역 예외처리 추가

### DIFF
--- a/backend/src/main/java/our/portfolio/devspace/common/dto/ErrorResponseBody.java
+++ b/backend/src/main/java/our/portfolio/devspace/common/dto/ErrorResponseBody.java
@@ -1,0 +1,31 @@
+package our.portfolio.devspace.common.dto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.validation.BindingResult;
+import our.portfolio.devspace.exception.ValidationError;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponseBody {
+
+    private final String message;
+    private List<ValidationError> errors;
+
+    public ErrorResponseBody(String message) {
+        this.message = message;
+    }
+
+    public ErrorResponseBody(String message, BindingResult bindingResult) {
+        this.message = message;
+        this.errors = bindingResult.getFieldErrors()
+            .stream()
+            .map(error -> new ValidationError(
+                error.getField(),
+                error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                error.getDefaultMessage()))
+            .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/domain/job/service/JobService.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/job/service/JobService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import our.portfolio.devspace.domain.job.entity.Job;
 import our.portfolio.devspace.domain.job.repository.JobRepository;
+import our.portfolio.devspace.exception.CustomException;
+import our.portfolio.devspace.exception.ErrorDetail;
 
 @Service
 @RequiredArgsConstructor
@@ -12,6 +14,6 @@ public class JobService {
     private final JobRepository jobRepository;
 
     public Job getJobById(Integer id) {
-        return jobRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 Job ID 입니다."));
+        return jobRepository.findById(id).orElseThrow(() -> new CustomException("Job Id " + id + "에 해당하는 직군이 없습니다.", ErrorDetail.JOB_NOT_FOUND));
     }
 }

--- a/backend/src/main/java/our/portfolio/devspace/domain/user/service/UserService.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/user/service/UserService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import our.portfolio.devspace.domain.user.entity.User;
 import our.portfolio.devspace.domain.user.repository.UserRepository;
+import our.portfolio.devspace.exception.CustomException;
+import our.portfolio.devspace.exception.ErrorDetail;
 
 @Service
 @RequiredArgsConstructor
@@ -12,6 +14,6 @@ public class UserService {
     private final UserRepository userRepository;
 
     public User getUserById(Long id) {
-        return userRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 User ID 입니다."));
+        return userRepository.findById(id).orElseThrow(() -> new CustomException("User Id " + id + "에 해당하는 유저가 없습니다.", ErrorDetail.USER_NOT_FOUND));
     }
 }

--- a/backend/src/main/java/our/portfolio/devspace/exception/CustomException.java
+++ b/backend/src/main/java/our/portfolio/devspace/exception/CustomException.java
@@ -1,0 +1,17 @@
+package our.portfolio.devspace.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException{
+    private final ErrorDetail errorDetail;
+
+    public CustomException(ErrorDetail errorDetail) {
+        super(errorDetail.getDescription());
+        this.errorDetail = errorDetail;
+    }
+    public CustomException(String message, ErrorDetail errorDetail) {
+        super(message);
+        this.errorDetail = errorDetail;
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/exception/ErrorDetail.java
+++ b/backend/src/main/java/our/portfolio/devspace/exception/ErrorDetail.java
@@ -1,0 +1,19 @@
+package our.portfolio.devspace.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorDetail {
+
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
+    VALIDATION_FAILED(HttpStatus.UNPROCESSABLE_ENTITY, "Validation Failed"),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "User Not Found"),
+    JOB_NOT_FOUND(HttpStatus.NOT_FOUND, "Job Not Found");
+
+    private final HttpStatus status;
+    private final String description;
+
+}

--- a/backend/src/main/java/our/portfolio/devspace/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/our/portfolio/devspace/exception/GlobalExceptionHandler.java
@@ -1,0 +1,31 @@
+package our.portfolio.devspace.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import our.portfolio.devspace.common.dto.ErrorResponseBody;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // HTTP Status Code: 422 Unprocessable Entity, Response Body: { message, errors: ValidationError}
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponseBody> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        ErrorResponseBody body = new ErrorResponseBody(ErrorDetail.VALIDATION_FAILED.getDescription(), e.getBindingResult());
+        return new ResponseEntity<>(body, ErrorDetail.VALIDATION_FAILED.getStatus());
+    }
+
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ErrorResponseBody> handleCustomException(CustomException e) {
+        ErrorResponseBody body = new ErrorResponseBody(e.getMessage());
+        return new ResponseEntity<>(body, e.getErrorDetail().getStatus());
+    }
+
+    // HTTP Status Code: 500 Internal Server Error, Response Body: { message }
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponseBody> handleOtherException() {
+        ErrorResponseBody body = new ErrorResponseBody("서버 에러로 요청에 응답할 수 없습니다.");
+        return new ResponseEntity<>(body, ErrorDetail.INTERNAL_SERVER_ERROR.getStatus());
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/exception/ValidationError.java
+++ b/backend/src/main/java/our/portfolio/devspace/exception/ValidationError.java
@@ -1,0 +1,14 @@
+package our.portfolio.devspace.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ValidationError {
+
+    private final String field;
+    private final String value;
+    private final String reason;
+
+}


### PR DESCRIPTION
- CustomException을 발생시킬 때 ErrorDetail을 인자로 넣어 어떤 상황에서 발생하는 예외인지 나타냅니다.
- CustomException의 인자로 ErrorDetail과 함께 message를 인자로 넣으면 ErrorDetail의 기본 description 대신 message가 ErrorResponseBody의 message로 들어갑니다.
- Controller에서 `@Valid`로 검증하고 검증에 실패하는 경우 그 내용이 ErrorResponseBody의 errors 필드로 들어갑니다.