### PR TITLE
포스트 생성 API 추가

### DIFF
--- a/backend/src/main/java/our/portfolio/devspace/domain/post/controller/PostController.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/post/controller/PostController.java
@@ -1,0 +1,30 @@
+package our.portfolio.devspace.domain.post.controller;
+
+import java.security.Principal;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import our.portfolio.devspace.common.dto.HttpResponseBody;
+import our.portfolio.devspace.domain.post.dto.PostCreationRequestDto;
+import our.portfolio.devspace.domain.post.dto.PostCreationResponseDto;
+import our.portfolio.devspace.domain.post.service.PostService;
+
+@RequiredArgsConstructor
+@RestController
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping("/api/posts")
+    public ResponseEntity<HttpResponseBody<PostCreationResponseDto>> createPost(@RequestBody @Valid PostCreationRequestDto dto, Principal userPrincipal) {
+        PostCreationResponseDto responseDto = postService.createPost(Long.parseLong(userPrincipal.getName()), dto);
+
+        // HTTP Status Code: 201 Created, Response Body: { message, data: PostCreationResponse}
+        HttpResponseBody<PostCreationResponseDto> body = new HttpResponseBody<>("등록되었습니다.", responseDto);
+        return new ResponseEntity<>(body, HttpStatus.CREATED);
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/domain/post/dto/PostCreationRequestDto.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/post/dto/PostCreationRequestDto.java
@@ -1,0 +1,46 @@
+package our.portfolio.devspace.domain.post.dto;
+
+import java.util.List;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+import our.portfolio.devspace.domain.post.entity.Post;
+import our.portfolio.devspace.domain.post.entity.PostHashtag;
+import our.portfolio.devspace.domain.profile.entity.Profile;
+
+@Getter
+public class PostCreationRequestDto {
+
+    private final String title;
+
+    @NotBlank
+    @Length(max = 16383, message = "본문 내용은 16,383자 이하로 입력하세요.") // MYSQL TEXT 타입 최대 65,535 byte / 4 (utf-8 한글자당 최대 4byte)
+    private final String content;
+
+    @NotNull
+    private final Boolean secret;
+
+    @Size(max = 10)
+    private final List<String> hashtags;
+
+    @Builder
+    public PostCreationRequestDto(String title, String content, Boolean secret, List<String> hashtags) {
+        this.title = title;
+        this.content = content;
+        this.secret = secret;
+        this.hashtags = hashtags;
+    }
+
+    public Post toEntity(Profile profile, List<PostHashtag> hashtags) {
+        return Post.builder()
+            .profile(profile)
+            .title(this.title)
+            .content(this.content)
+            .secret(this.secret)
+            .hashtagsOfPost(hashtags)
+            .build();
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/domain/post/dto/PostCreationResponseDto.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/post/dto/PostCreationResponseDto.java
@@ -1,0 +1,16 @@
+package our.portfolio.devspace.domain.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import our.portfolio.devspace.domain.post.entity.Post;
+
+@Getter
+@AllArgsConstructor
+public class PostCreationResponseDto {
+
+    private final Long id;
+
+    public static PostCreationResponseDto from(Post post) {
+        return new PostCreationResponseDto(post.getId());
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/domain/post/entity/Hashtag.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/post/entity/Hashtag.java
@@ -1,0 +1,34 @@
+package our.portfolio.devspace.domain.post.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "hashtags")
+@Entity
+public class Hashtag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @OneToMany(mappedBy = "hashtag")
+    private final List<PostHashtag> postsOfHashtag = new ArrayList<>();
+
+    public Hashtag(String name) {
+        this.name = name;
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/domain/post/entity/Post.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/post/entity/Post.java
@@ -1,0 +1,62 @@
+package our.portfolio.devspace.domain.post.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import our.portfolio.devspace.domain.BaseTimeEntity;
+import our.portfolio.devspace.domain.profile.entity.Profile;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "posts")
+@Entity
+public class Post extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_id", nullable = false)
+    private Profile profile;
+
+    @Column(nullable = false)
+    private Boolean secret;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST)
+    private final List<PostHashtag> hashtagsOfPost = new ArrayList<>();
+
+    @Builder
+    public Post(String title, String content, Profile profile, Boolean secret, List<PostHashtag> hashtagsOfPost) {
+        this.title = title;
+        this.content = content;
+        this.profile = profile;
+        this.secret = secret;
+        addHashtags(hashtagsOfPost);
+    }
+
+    private void addHashtags(List<PostHashtag> hashtagsOfPost) {
+        this.hashtagsOfPost.addAll(hashtagsOfPost);
+        this.hashtagsOfPost.forEach(hashtag -> hashtag.setPost(this));
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/domain/post/entity/PostHashtag.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/post/entity/PostHashtag.java
@@ -1,0 +1,38 @@
+package our.portfolio.devspace.domain.post.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "post_hashtag")
+@Entity
+public class PostHashtag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter(AccessLevel.PACKAGE)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hashtag_id")
+    private Hashtag hashtag;
+
+    public PostHashtag(Hashtag hashtag) {
+        this.hashtag = hashtag;
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/domain/post/repository/HashtagRepository.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/post/repository/HashtagRepository.java
@@ -1,0 +1,11 @@
+package our.portfolio.devspace.domain.post.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import our.portfolio.devspace.domain.post.entity.Hashtag;
+
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+
+    List<Hashtag> findByNameIn(List<String> hashtagName);
+
+}

--- a/backend/src/main/java/our/portfolio/devspace/domain/post/repository/PostRepository.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/post/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package our.portfolio.devspace.domain.post.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import our.portfolio.devspace.domain.post.entity.Post;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/backend/src/main/java/our/portfolio/devspace/domain/post/service/HashtagService.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/post/service/HashtagService.java
@@ -1,0 +1,51 @@
+package our.portfolio.devspace.domain.post.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import our.portfolio.devspace.domain.post.entity.Hashtag;
+import our.portfolio.devspace.domain.post.entity.PostHashtag;
+import our.portfolio.devspace.domain.post.repository.HashtagRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class HashtagService {
+
+    private final HashtagRepository hashtagRepository;
+
+    public List<PostHashtag> getHashtagsOfPost(List<String> hashtagNames) {
+        List<Hashtag> hashtags = getOrCreateHashtags(hashtagNames);
+        // DB에 등록된 해시태그를 PostHashtag에 세팅한 후 반환한다.
+        return hashtags.stream().map(PostHashtag::new).collect(Collectors.toList());
+    }
+
+    // DB에서 해시태그를 가지고 오고, DB에 없으면 등록한 후 가지고 온다.
+    private List<Hashtag> getOrCreateHashtags(List<String> hashtagNames) {
+        List<Hashtag> existingHashtags = getHashtagsByNameIn(hashtagNames);
+        removeExistingHashtag(hashtagNames, existingHashtags);
+        List<Hashtag> newHashtag = createHashtags(hashtagNames);
+        newHashtag.addAll(existingHashtags);
+        return newHashtag;
+    }
+
+    // hashtagNames에 포함된 태그명으로 DB에 검색한다.
+    private List<Hashtag> getHashtagsByNameIn(List<String> hashtagNames) {
+        return hashtagRepository.findByNameIn(hashtagNames);
+    }
+
+    // hashtagNames 중 DB에 이미 존재하는 해시태그를 제거한다.
+    private void removeExistingHashtag(List<String> hashtagNames, List<Hashtag> existingHashtags) {
+        existingHashtags.forEach(hashtag -> hashtagNames.remove(hashtag.getName()));
+    }
+
+    // hashtagNames를 Hashtag 엔티티로 매핑하여 DB에 등록한다.
+    private List<Hashtag> createHashtags(List<String> hashtagNames) {
+        return hashtagRepository.saveAll(
+            hashtagNames.stream().map(Hashtag::new).collect(Collectors.toList())
+        );
+    }
+
+}

--- a/backend/src/main/java/our/portfolio/devspace/domain/post/service/PostService.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/post/service/PostService.java
@@ -1,0 +1,32 @@
+package our.portfolio.devspace.domain.post.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import our.portfolio.devspace.domain.post.dto.PostCreationRequestDto;
+import our.portfolio.devspace.domain.post.dto.PostCreationResponseDto;
+import our.portfolio.devspace.domain.post.entity.Post;
+import our.portfolio.devspace.domain.post.entity.PostHashtag;
+import our.portfolio.devspace.domain.post.repository.PostRepository;
+import our.portfolio.devspace.domain.profile.entity.Profile;
+import our.portfolio.devspace.domain.profile.service.ProfileService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostService {
+
+    private final ProfileService profileService;
+    private final HashtagService hashtagService;
+    private final PostRepository postRepository;
+
+    public PostCreationResponseDto createPost(Long userId, PostCreationRequestDto dto) {
+        Profile profile = profileService.getProfileById(userId);
+        List<PostHashtag> hashtags = hashtagService.getHashtagsOfPost(dto.getHashtags());
+        Post post = dto.toEntity(profile, hashtags);
+
+        // 저장된 Post를 DTO로 변환하여 반환한다.
+        return PostCreationResponseDto.from(postRepository.save(post));
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/domain/profile/entity/Profile.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/profile/entity/Profile.java
@@ -1,5 +1,7 @@
 package our.portfolio.devspace.domain.profile.entity;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -7,6 +9,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.MapsId;
+import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -14,6 +17,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import our.portfolio.devspace.domain.BaseTimeEntity;
 import our.portfolio.devspace.domain.job.entity.Job;
+import our.portfolio.devspace.domain.post.entity.Post;
 import our.portfolio.devspace.domain.user.entity.User;
 
 @Getter
@@ -26,7 +30,7 @@ public class Profile extends BaseTimeEntity {
     private Long id;
 
     @MapsId
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
@@ -40,17 +44,20 @@ public class Profile extends BaseTimeEntity {
     @JoinColumn(name = "job_id", nullable = false)
     private Job job;
 
-    private String profile_image;
-    private String profile_bg_image;
+    @OneToMany(mappedBy = "profile")
+    private final List<Post> posts = new ArrayList<>();
+
+    private String image;
+    private String backgroundImage;
 
     @Builder
-    public Profile(User user, String name, String introduction, Job job, String profile_image,
-        String profile_bg_image) {
+    public Profile(User user, String name, String introduction, Job job, String image,
+        String backgroundImage) {
         this.user = user;
         this.name = name;
         this.introduction = introduction;
         this.job = job;
-        this.profile_image = profile_image;
-        this.profile_bg_image = profile_bg_image;
+        this.image = image;
+        this.backgroundImage = backgroundImage;
     }
 }

--- a/backend/src/main/java/our/portfolio/devspace/domain/profile/service/ProfileService.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/profile/service/ProfileService.java
@@ -10,16 +10,18 @@ import our.portfolio.devspace.domain.profile.entity.Profile;
 import our.portfolio.devspace.domain.profile.repository.ProfileRepository;
 import our.portfolio.devspace.domain.user.entity.User;
 import our.portfolio.devspace.domain.user.service.UserService;
+import our.portfolio.devspace.exception.CustomException;
+import our.portfolio.devspace.exception.ErrorDetail;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class ProfileService {
 
     private final UserService userService;
     private final JobService jobService;
     private final ProfileRepository profileRepository;
 
-    @Transactional
     public ProfileCreationDto createProfile(Long userId, ProfileCreationDto dto) {
         User user = userService.getUserById(userId);
         Job job = jobService.getJobById(dto.getJobId());
@@ -34,5 +36,11 @@ public class ProfileService {
 
         // 프로필을 저장하고 DTO로 변환한 후 리턴한다.
         return ProfileCreationDto.from(profileRepository.save(profile));
+    }
+
+    public Profile getProfileById(Long userId) {
+        return profileRepository.findById(userId).orElseThrow(() ->
+            new CustomException("User Id " + userId + "에 해당하는 사용자의 프로필이 없습니다.", ErrorDetail.PROFILE_NOT_FOUND)
+        );
     }
 }

--- a/backend/src/main/java/our/portfolio/devspace/exception/ErrorDetail.java
+++ b/backend/src/main/java/our/portfolio/devspace/exception/ErrorDetail.java
@@ -11,6 +11,7 @@ public enum ErrorDetail {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
     VALIDATION_FAILED(HttpStatus.UNPROCESSABLE_ENTITY, "Validation Failed"),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "User Not Found"),
+    PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "Profile Not Found"),
     JOB_NOT_FOUND(HttpStatus.NOT_FOUND, "Job Not Found");
 
     private final HttpStatus status;

--- a/backend/src/test/java/our/portfolio/devspace/common/ControllerTestUtils.java
+++ b/backend/src/test/java/our/portfolio/devspace/common/ControllerTestUtils.java
@@ -1,10 +1,19 @@
 package our.portfolio.devspace.common;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
+import com.epages.restdocs.apispec.FieldDescriptors;
 import com.epages.restdocs.apispec.HeaderDescriptorWithType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
 
 public class ControllerTestUtils {
+
+    public static FieldDescriptors fieldDescriptorsWithMessage(FieldDescriptors baseDescriptor) {
+        return new FieldDescriptors(fieldWithPath("message").description("메시지").type(JsonFieldType.STRING))
+            .andWithPrefix("data.", baseDescriptor.getFieldDescriptors().toArray(new FieldDescriptor[0]));
+    }
 
     public static HeaderDescriptorWithType authorizationHeader() {
         return headerWithName("Authorization").description("Access Token");

--- a/backend/src/test/java/our/portfolio/devspace/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/our/portfolio/devspace/domain/post/controller/PostControllerTest.java
@@ -1,0 +1,110 @@
+package our.portfolio.devspace.domain.post.controller;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.epages.restdocs.apispec.Schema.schema;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ConstrainedFields;
+import com.epages.restdocs.apispec.FieldDescriptors;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import our.portfolio.devspace.common.CommonTestUtils;
+import our.portfolio.devspace.common.ControllerTestUtils;
+import our.portfolio.devspace.common.dto.HttpResponseBody;
+import our.portfolio.devspace.configuration.security.oauth.jwt.JwtTokenProvider;
+import our.portfolio.devspace.domain.post.dto.PostCreationRequestDto;
+import our.portfolio.devspace.domain.post.dto.PostCreationResponseDto;
+import our.portfolio.devspace.domain.post.service.PostService;
+
+@AutoConfigureRestDocs
+@WebMvcTest(PostController.class)
+class PostControllerTest {
+
+    @MockBean
+    JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    PostService postService;
+
+    @Test
+    @WithMockUser(username = "1")
+    public void createPost() throws Exception {
+        // ** Given **
+        // Mock 객체인 PostService의 createPost를 실행하면 requestDto를 반환한다.
+        PostCreationResponseDto responseDto = new PostCreationResponseDto(1L);
+        given(postService.createPost(anyLong(), any(PostCreationRequestDto.class))).willReturn(responseDto);
+
+        // ** When **
+        ResultActions resultActions = postCreationResultActions();
+
+        // ** Then **
+        // HTTP Status Code 201, 응답 본문에는 ResponseEntity로 생성된 포스트 ID가 포함된다.
+        HttpResponseBody<PostCreationResponseDto> body = new HttpResponseBody<>("등록되었습니다.", responseDto);
+        resultActions.andExpectAll(
+            status().isCreated(),
+            content().json(CommonTestUtils.valueToString(body))
+        );
+
+        // ** API Docs **
+        resultActions.andDo(
+            document("포스트를 성공적으로 생성한다", resource(ResourceSnippetParameters.builder()
+                .summary("포스트 생성")
+                .tag("Post")
+                .requestSchema(schema("PostCreationRequest"))
+                .requestHeaders(ControllerTestUtils.authorizationHeader())
+                .requestFields(postCreationDescriptors())
+                .responseSchema(schema("PostCreationResponse"))
+                .responseFields(ControllerTestUtils.fieldDescriptorsWithMessage(
+                    new FieldDescriptors(fieldWithPath("id").description("생성한 포스트 ID").type(JsonFieldType.NUMBER))))
+                .build())));
+    }
+
+    private ResultActions postCreationResultActions() throws Exception {
+        return mockMvc.perform(
+            post("/api/posts")
+                .content(CommonTestUtils.valueToString(postCreationRequestDto()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", ControllerTestUtils.authorizationToken())
+                .with(csrf())
+        );
+    }
+
+    private PostCreationRequestDto postCreationRequestDto() {
+        return PostCreationRequestDto.builder()
+            .title("제목")
+            .content("본문")
+            .secret(false)
+            .hashtags(List.of("#태그1", "#태그2", "#태그3"))
+            .build();
+    }
+
+    private FieldDescriptors postCreationDescriptors() {
+        ConstrainedFields postCreationDtoField = new ConstrainedFields(PostCreationRequestDto.class);
+        return new FieldDescriptors(
+            postCreationDtoField.withPath("title").description("포스트 제목").type(JsonFieldType.STRING),
+            postCreationDtoField.withPath("content").description("포스트 본문").type(JsonFieldType.STRING),
+            postCreationDtoField.withPath("secret").description("나만 보기 설정").type(JsonFieldType.BOOLEAN),
+            postCreationDtoField.withPath("hashtags").description("해시태그 목록").type(JsonFieldType.ARRAY));
+    }
+}

--- a/backend/src/test/java/our/portfolio/devspace/domain/post/repository/HashtagRepositoryTest.java
+++ b/backend/src/test/java/our/portfolio/devspace/domain/post/repository/HashtagRepositoryTest.java
@@ -1,0 +1,39 @@
+package our.portfolio.devspace.domain.post.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import our.portfolio.devspace.domain.post.entity.Hashtag;
+
+@DataJpaTest
+class HashtagRepositoryTest {
+
+    @Autowired
+    HashtagRepository hashtagRepository;
+
+    @Test
+    public void findByNameIn() {
+        // ** Given **
+        List<String> hashtagNames = new ArrayList<>(List.of("#태그1", "#태그2", "#태그3"));
+        List<Hashtag> hashtags = List.of(
+            new Hashtag("#태그1"),
+            new Hashtag("#태그2"),
+            new Hashtag("#태그4")
+        );
+        hashtagRepository.saveAll(hashtags);
+
+        // ** When **
+        List<Hashtag> existingHashtags = hashtagRepository.findByNameIn(hashtagNames);
+
+        // ** Then ** hashtagNames에 없는 태그명은 검색되지 않는다.
+        Condition<Hashtag> contain = new Condition<>(hashtag -> hashtagNames.contains(hashtag.getName()), "포함");
+        Condition<Hashtag> notContain = new Condition<>(hashtag -> hashtag.getName().equals("#태그4"), "불포함");
+        assertThat(existingHashtags).have(contain);
+        assertThat(existingHashtags).doNotHave(notContain);
+    }
+}

--- a/backend/src/test/java/our/portfolio/devspace/domain/post/service/HashtagServiceTest.java
+++ b/backend/src/test/java/our/portfolio/devspace/domain/post/service/HashtagServiceTest.java
@@ -1,0 +1,45 @@
+package our.portfolio.devspace.domain.post.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import our.portfolio.devspace.domain.post.entity.Hashtag;
+import our.portfolio.devspace.domain.post.entity.PostHashtag;
+import our.portfolio.devspace.domain.post.repository.HashtagRepository;
+
+@ExtendWith(MockitoExtension.class)
+class HashtagServiceTest {
+
+    @Mock
+    HashtagRepository hashtagRepository;
+
+    @InjectMocks
+    HashtagService hashtagService;
+
+    @Test
+    public void getHashtagsOfPost() {
+        // ** Given **
+        List<String> hashtags = new ArrayList<>(List.of("#태그1", "#태그2", "#태그3"));
+        List<Hashtag> existingHashtags = new ArrayList<>(List.of(new Hashtag("#태그1"), new Hashtag("#태그2")));
+        List<Hashtag> newHashtags = new ArrayList<>(List.of(new Hashtag("#태그1")));
+
+        given(hashtagRepository.findByNameIn(anyList())).willReturn(existingHashtags);
+        given(hashtagRepository.saveAll(anyList())).willReturn(newHashtags);
+
+        // ** When ** getHashtagsOfPost를 실행하면
+        List<PostHashtag> hashtagsOfPost = hashtagService.getHashtagsOfPost(hashtags);
+
+        // ** Then ** hashtag 필드가 Hashtag 엔티티로 채워진 List<PostHashtag>를 반환한다.
+        assertThat(hashtagsOfPost).allSatisfy(hashtag -> {
+            assertThat(hashtag.getHashtag()).isNotNull();
+        });
+    }
+}


### PR DESCRIPTION
- URI: POST /api/posts
- 차후 cascade.REMOVE 적용을 위해 Post와 Hashtag N:N 관계를 1:N, N:1로 풀었습니다.
- API 상세 규약은 아직 정해진 바가 없어 디자인을 참고했고 회의 통해서 확실히 정해지면 수정할 예정입니다.