### PR TITLE
컨트롤러에서 사용할 UserId annotation 추가

### DIFF
--- a/backend/src/main/java/our/portfolio/devspace/configuration/WebMvcConfiguration.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/WebMvcConfiguration.java
@@ -1,0 +1,19 @@
+package our.portfolio.devspace.configuration;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import our.portfolio.devspace.configuration.security.oauth.domain.UserIdArgumentResolver;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebMvcConfiguration implements WebMvcConfigurer {
+    private final UserIdArgumentResolver userIdArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(userIdArgumentResolver);
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/domain/UserId.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/domain/UserId.java
@@ -1,0 +1,12 @@
+package our.portfolio.devspace.configuration.security.oauth.domain;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserId {
+
+}

--- a/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/domain/UserIdArgumentResolver.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/security/oauth/domain/UserIdArgumentResolver.java
@@ -1,0 +1,26 @@
+package our.portfolio.devspace.configuration.security.oauth.domain;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean isUserIdAnnotation = parameter.hasParameterAnnotation(UserId.class);
+        boolean isLongType = parameter.getParameterType().isAssignableFrom(Long.class);
+        return isUserIdAnnotation && isLongType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+        return Long.parseLong(userId);
+    }
+}

--- a/backend/src/main/java/our/portfolio/devspace/domain/post/controller/PostController.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/post/controller/PostController.java
@@ -1,6 +1,5 @@
 package our.portfolio.devspace.domain.post.controller;
 
-import java.security.Principal;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -9,6 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import our.portfolio.devspace.common.dto.HttpResponseBody;
+import our.portfolio.devspace.configuration.security.oauth.domain.UserId;
 import our.portfolio.devspace.domain.post.dto.PostCreationRequestDto;
 import our.portfolio.devspace.domain.post.dto.PostCreationResponseDto;
 import our.portfolio.devspace.domain.post.service.PostService;
@@ -20,8 +20,8 @@ public class PostController {
     private final PostService postService;
 
     @PostMapping("/api/posts")
-    public ResponseEntity<HttpResponseBody<PostCreationResponseDto>> createPost(@RequestBody @Valid PostCreationRequestDto dto, Principal userPrincipal) {
-        PostCreationResponseDto responseDto = postService.createPost(Long.parseLong(userPrincipal.getName()), dto);
+    public ResponseEntity<HttpResponseBody<PostCreationResponseDto>> createPost(@RequestBody @Valid PostCreationRequestDto dto, @UserId Long userId) {
+        PostCreationResponseDto responseDto = postService.createPost(userId, dto);
 
         // HTTP Status Code: 201 Created, Response Body: { message, data: PostCreationResponse}
         HttpResponseBody<PostCreationResponseDto> body = new HttpResponseBody<>("등록되었습니다.", responseDto);

--- a/backend/src/main/java/our/portfolio/devspace/domain/profile/controller/ProfileController.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/profile/controller/ProfileController.java
@@ -1,6 +1,5 @@
 package our.portfolio.devspace.domain.profile.controller;
 
-import java.security.Principal;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -9,6 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import our.portfolio.devspace.common.dto.HttpResponseBody;
+import our.portfolio.devspace.configuration.security.oauth.domain.UserId;
 import our.portfolio.devspace.domain.profile.dto.CreateProfileRequest;
 import our.portfolio.devspace.domain.profile.dto.CreateProfileResponse;
 import our.portfolio.devspace.domain.profile.service.ProfileService;
@@ -20,8 +20,8 @@ public class ProfileController {
     private final ProfileService profileService;
 
     @PostMapping(value = "/api/profiles")
-    public ResponseEntity<HttpResponseBody<CreateProfileResponse>> createProfile(@RequestBody @Valid CreateProfileRequest requestDto, Principal userPrincipal) {
-        CreateProfileResponse responseDto = profileService.createProfile(Long.parseLong(userPrincipal.getName()), requestDto);
+    public ResponseEntity<HttpResponseBody<CreateProfileResponse>> createProfile(@RequestBody @Valid CreateProfileRequest requestDto, @UserId Long userId) {
+        CreateProfileResponse responseDto = profileService.createProfile(userId, requestDto);
 
         // HTTP Status Code: 201 Created, Response Body: { message, data: CreateProfileResponse}
         HttpResponseBody<CreateProfileResponse> body = new HttpResponseBody<>("프로필이 저장되었습니다.", responseDto);


### PR DESCRIPTION
- 기존에 Principal을 매개변수로 받아 UserId를 얻던 것을 Long 타입 UserId를 바로 매개변수로 받을 수 있도록 변경했습니다.
- 사용은 `@UserId Long userId`로 할 수 있습니다.
```java
@PostMapping("/api/posts")
    public ResponseEntity<HttpResponseBody<PostCreationResponseDto>> createPost(@RequestBody @Valid PostCreationRequestDto dto, @UserId Long userId) {
        PostCreationResponseDto responseDto = postService.createPost(userId, dto);

        // HTTP Status Code: 201 Created, Response Body: { message, data: PostCreationResponse}
        HttpResponseBody<PostCreationResponseDto> body = new HttpResponseBody<>("등록되었습니다.", responseDto);
        return new ResponseEntity<>(body, HttpStatus.CREATED);
    }
```