### PR TITLE
직군 목록 API의 컨트롤러가 직군 타입을 Enum으로 받도록 변경

### DIFF
--- a/backend/src/main/java/our/portfolio/devspace/domain/job/controller/JobController.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/job/controller/JobController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 import our.portfolio.devspace.common.dto.HttpResponseBody;
 import our.portfolio.devspace.domain.job.dto.JobResponse;
+import our.portfolio.devspace.domain.job.entity.JobType;
 import our.portfolio.devspace.domain.job.service.JobService;
 
 @RequiredArgsConstructor
@@ -17,7 +18,7 @@ public class JobController {
     private final JobService jobService;
 
     @GetMapping("/api/jobs/{type}")
-    public ResponseEntity<HttpResponseBody<List<JobResponse>>> listJobs(@PathVariable String type) {
+    public ResponseEntity<HttpResponseBody<List<JobResponse>>> listJobs(@PathVariable JobType type) {
         HttpResponseBody<List<JobResponse>> body = new HttpResponseBody<>("직군 목록이 조회되었습니다.", jobService.listJobs(type));
         return new ResponseEntity<>(body, HttpStatus.OK);
     }

--- a/backend/src/main/java/our/portfolio/devspace/domain/job/service/JobService.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/job/service/JobService.java
@@ -18,8 +18,8 @@ public class JobService {
     private final JobMapper jobMapper;
     private final JobRepository jobRepository;
 
-    public List<JobResponse> listJobs(String type) {
-        return jobMapper.toJobResponses(jobRepository.findAllByType(JobType.valueOf(type.toUpperCase())));
+    public List<JobResponse> listJobs(JobType type) {
+        return jobMapper.toJobResponses(jobRepository.findAllByType(type));
     }
 
     public Job getJobById(Integer id) {

--- a/backend/src/test/java/our/portfolio/devspace/domain/job/controller/JobControllerTest.java
+++ b/backend/src/test/java/our/portfolio/devspace/domain/job/controller/JobControllerTest.java
@@ -4,6 +4,7 @@ import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.docume
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static com.epages.restdocs.apispec.Schema.schema;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -52,7 +53,7 @@ class JobControllerTest {
     void listJobs() throws Exception {
         // ** Given **
         List<JobResponse> responseDto = JobFactory.jobResponses(JobType.DEVELOPER);
-        given(jobService.listJobs(anyString())).willReturn(responseDto);
+        given(jobService.listJobs(JobType.DEVELOPER)).willReturn(responseDto);
 
         // ** When **
         ResultActions resultActions = mockMvc.perform(get("/api/jobs/{type}", "developer")

--- a/backend/src/test/java/our/portfolio/devspace/domain/job/service/JobServiceTest.java
+++ b/backend/src/test/java/our/portfolio/devspace/domain/job/service/JobServiceTest.java
@@ -35,9 +35,10 @@ class JobServiceTest {
     @ParameterizedTest(name = "{0}에 해당하는 직군 목록을 반환한다.")
     @ValueSource(strings = {"developer", "designer", "marketer", "planner", "startup"})
     @DisplayName("직군 목록을 반환한다.")
-    void listJobs(String type) throws IllegalAccessException {
+    void listJobs(String typeString) throws IllegalAccessException {
         // ** Given **
-        List<Job> jobs = JobFactory.jobEntities(JobType.valueOf(type.toUpperCase()));
+        JobType type = JobType.valueOf(typeString.toUpperCase());
+        List<Job> jobs = JobFactory.jobEntities(type);
 
         given(jobRepository.findAllByType(any(JobType.class))).will(invocation -> JobFactory.jobEntities(invocation.getArgument(0)));
         given(jobMapper.toJobResponses(anyList())).will(invocation -> {


### PR DESCRIPTION
- `JobController.listJobs()`의 `String type` 파라미터를 `JobType type`으로 변경했습니다.
- `JobService.listJobs()`의 `String type` 파라미터를 `JobType type`으로 변경했습니다.
- `JobService`에서 String을 Enum으로 변환하는 코드를 삭제했습니다.
- `EnumConverterFactory`가 String을 Enum으로 변환하여 바인딩하고, 변환에 실패할 경우 에러 메시지와 함께 Status 422로 응답합니다.