### PR TITLE
일부 Entity 필드의 Not Null 설정 추가

### DIFF
--- a/backend/src/main/java/our/portfolio/devspace/domain/BaseTimeEntity.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/BaseTimeEntity.java
@@ -1,6 +1,7 @@
 package our.portfolio.devspace.domain;
 
 import java.time.LocalDateTime;
+import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 import lombok.Getter;
@@ -14,9 +15,11 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class BaseTimeEntity {
 
     @CreatedDate
+    @Column(nullable = false)
     private LocalDateTime createdDate;
 
     @LastModifiedDate
+    @Column(nullable = false)
     private LocalDateTime modifiedDate;
 
 }

--- a/backend/src/main/java/our/portfolio/devspace/domain/profile/entity/ReferenceLink.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/profile/entity/ReferenceLink.java
@@ -26,7 +26,7 @@ public class ReferenceLink {
 
     @Setter(AccessLevel.PACKAGE)
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "profile_id")
+    @JoinColumn(name = "profile_id", nullable = false)
     private Profile profile;
 
     @Column(nullable = false, length = 10)


### PR DESCRIPTION
- BaseTimeEntity의 createdDate, modifiedDate에 `nullable=false` 설정을 추가했습니다.
- ReferenceLink의 post_id에 `nullable=false` 설정을 추가했습니다.