### PR TITLE
SQL Dialect를 MySQL8Dialect로 변경

### DIFF
--- a/backend/src/main/java/our/portfolio/devspace/configuration/jpa/ImprovedMySQL8Dialect.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/jpa/ImprovedMySQL8Dialect.java
@@ -1,0 +1,14 @@
+package our.portfolio.devspace.configuration.jpa;
+
+import org.hibernate.dialect.MySQL8Dialect;
+
+public class ImprovedMySQL8Dialect extends MySQL8Dialect {
+
+    /**
+     * 테이블이 없을 때 "ALTER TABLE"을 실행하여 발생하는 예외를 수정하기 위해 SQL "ALTER TABLE"의 뒤에 "IF EXISTS"를 추가한다.
+     */
+    @Override
+    public boolean supportsIfExistsAfterAlterTable() {
+        return true;
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -17,8 +17,9 @@ spring:
       ddl-auto: create # 어플리케이션 시작 시 기존 테이블 삭제 후 재생성
     properties:
       hibernate:
+        auto_quote_keyword: true # 예약어 사용을 방지하기 위한 따옴표 추가 설정
         format_sql: true # SQL 출력 줄바꿈 적용
-        dialect: org.hibernate.dialect.MySQL57Dialect
+        dialect: our.portfolio.devspace.configuration.jpa.ImprovedMySQL8Dialect # SQL 방언 설정
     show-sql: true # 실행되는 SQL 출력
     defer-datasource-initialization: true # Hibernate 초기화 이후 data.sql DML 실행
   sql:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  test:
+    database:
+      replace: none
   ## DB
   h2:
     console:
@@ -15,9 +18,7 @@ spring:
     properties:
       hibernate:
         format_sql: true # SQL 출력 줄바꿈 적용
-        dialect:
-          nodeValue: MySQL8Dialect # SQL 방언 설정
-          storage_engine: innodb # 스토리지 엔진 설정
+        dialect: org.hibernate.dialect.MySQL57Dialect
     show-sql: true # 실행되는 SQL 출력
     defer-datasource-initialization: true # Hibernate 초기화 이후 data.sql DML 실행
   sql:


### PR DESCRIPTION
- SQL 방언을 `MySQL8Dialect`로 변경했습니다.
- `MySQL8Dialect`로 변경한 후, `ddl-auto`의 설정에 따라 기존 테이블의 제약 조건을 삭제하도록 동작하는 과정에서 아직 생성되지 않은 테이블을 변경하는 문제를 수정했습니다.
  - `MySQL8Dialect`를 상속받아 `ALTER TABLE`의 뒤에 `IF EXISTS`를 추가하도록 메소드를 오버라이딩한 `ImprovedMySQL8Dialect`를 만들어 SQL 방언으로 적용했습니다.
- 테스트코드에서 application.yml에 설정된 DataSource를 사용하지 않고 기본값의 DataSource로 대체하는 동작을 수정하기 위해 관련 설정을 추가했습니다.