### PR TITLE
feat: 좋아요 추가 기능 구현

### DIFF
--- a/backend/src/main/java/our/portfolio/devspace/common/mapper/LikeMapper.java
+++ b/backend/src/main/java/our/portfolio/devspace/common/mapper/LikeMapper.java
@@ -1,0 +1,16 @@
+package our.portfolio.devspace.common.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import our.portfolio.devspace.domain.like.dto.CreateLikeResponse;
+import our.portfolio.devspace.domain.like.entity.Like;
+
+@Mapper(uses = {EntityMapper.class})
+public interface LikeMapper {
+
+    CreateLikeResponse toCreateLikeResponse(Like like);
+
+    @Mapping(source = "postId", target = "post", qualifiedBy = {EntityMapper.IdToEntity.class})
+    @Mapping(source = "userId", target = "profile", qualifiedBy = {EntityMapper.IdToEntity.class})
+    Like toEntity(Long postId, Long userId);
+}

--- a/backend/src/main/java/our/portfolio/devspace/configuration/WebSecurityConfiguration.java
+++ b/backend/src/main/java/our/portfolio/devspace/configuration/WebSecurityConfiguration.java
@@ -40,6 +40,7 @@ public class WebSecurityConfiguration {
                 .antMatchers(HttpMethod.POST, "/api/profiles").hasRole("USER")
                 .antMatchers(HttpMethod.GET, "/api/jobs").hasRole("USER")
                 .antMatchers(HttpMethod.POST, "/api/posts").hasRole("USER")
+                .antMatchers(HttpMethod.POST,"/api/like").hasRole("USER")
                 .anyRequest().permitAll()
             )
             .exceptionHandling()

--- a/backend/src/main/java/our/portfolio/devspace/domain/like/controller/LikeController.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/like/controller/LikeController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import our.portfolio.devspace.common.dto.HttpResponseBody;
+import our.portfolio.devspace.configuration.security.oauth.domain.UserId;
+import our.portfolio.devspace.domain.like.dto.CreateLikeResponse;
 import our.portfolio.devspace.domain.like.dto.GetLikeResponse;
 import our.portfolio.devspace.domain.like.service.LikeService;
 
@@ -37,9 +39,13 @@ public class LikeController {
         return ResponseEntity.status(HttpStatus.OK).body(body);
     }
 
-    @PostMapping("api/like/{id}")
-    public void createLike(@PathVariable Long id) {
-        likeService.createLike(id);
+    @PostMapping("api/like/{postId}")
+    public ResponseEntity<HttpResponseBody<CreateLikeResponse>> createLike(@PathVariable Long postId, @UserId Long userId) {
+
+        CreateLikeResponse responseDto = likeService.createLike(postId, userId);
+        HttpResponseBody<CreateLikeResponse> body = new HttpResponseBody<>("좋아요 회원이 등록 되었습니다.", responseDto);
+
+        return ResponseEntity.status(HttpStatus.OK).body(body);
     }
 
 }

--- a/backend/src/main/java/our/portfolio/devspace/domain/like/dto/CreateLikeResponse.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/like/dto/CreateLikeResponse.java
@@ -1,0 +1,6 @@
+package our.portfolio.devspace.domain.like.dto;
+
+public class CreateLikeResponse {
+
+    private Long id;
+}

--- a/backend/src/main/java/our/portfolio/devspace/domain/like/service/LikeService.java
+++ b/backend/src/main/java/our/portfolio/devspace/domain/like/service/LikeService.java
@@ -3,7 +3,10 @@ package our.portfolio.devspace.domain.like.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import our.portfolio.devspace.common.mapper.LikeMapper;
+import our.portfolio.devspace.domain.like.dto.CreateLikeResponse;
 import our.portfolio.devspace.domain.like.dto.GetLikeResponse;
+import our.portfolio.devspace.domain.like.entity.Like;
 import our.portfolio.devspace.domain.like.repository.LikeRepository;
 import our.portfolio.devspace.exception.CustomException;
 
@@ -16,6 +19,7 @@ import static our.portfolio.devspace.exception.ErrorDetail.INVALID_PARAMETER_VAL
 public class LikeService {
 
     private final LikeRepository likeRepository;
+    private final LikeMapper likeMapper;
 
     public List<GetLikeResponse> listLikes(Long id, Pageable pageable) {
 
@@ -23,5 +27,12 @@ public class LikeService {
             throw new CustomException(INVALID_PARAMETER_VALUE);
         }
         return likeRepository.findLikeUserByPostId(id, pageable);
+    }
+
+    public CreateLikeResponse createLike(Long postId, Long userId) {
+        Like like = likeMapper.toEntity(postId, userId);
+        likeRepository.save(like);
+
+        return likeMapper.toCreateLikeResponse(like);
     }
 }


### PR DESCRIPTION
좋아요 추가 기능 구현
- postMapping 으로 "api/like/{postId}"로 요청하면 등록된 정보가 json 형식으로 반환
- 좋아요 추가는 로그인 한 상태에서만 접근 가능하도록 WebSecurityConfiguration 에서 설정 추가